### PR TITLE
Fix Column make method binding

### DIFF
--- a/src/Columns/Column.php
+++ b/src/Columns/Column.php
@@ -32,9 +32,9 @@ class Column
         $this->field = strtolower(str_replace(' ', '_', $name));
     }
 
-    public static function make(string $name): self
+    public static function make(string $name): static
     {
-        return new self($name);
+        return new static($name);
     }
 
     public function field(string $field): self


### PR DESCRIPTION
## Summary
- return `static` from `Column::make` to support late static binding

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400a38360c8322a2712b505079bd90