### PR TITLE
Implement clickable rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,24 @@ public function rowActionDelete($row)
 }
 ```
 
+### Clickable Rows
+
+Make the entire row clickable by overriding the `showRecord` method on your table. You can redirect or dispatch a Livewire event from here:
+
+```php
+class UsersTable extends Table
+{
+    public function showRecord($id)
+    {
+        // Redirect to a detail page
+        return redirect()->route('users.show', $id);
+
+        // Or dispatch an event to open a drawer
+        // $this->dispatch('openUserDrawer', id: $id);
+    }
+}
+```
+
 ### Global Actions
 
 ```php

--- a/resources/views/partials/row-actions.blade.php
+++ b/resources/views/partials/row-actions.blade.php
@@ -26,7 +26,7 @@
             <div class="py-1">
                 @foreach($this->getRecordActions($record) as $action)
                     <button
-                        wire:click="executeRowAction('{{ $action->getKey() }}', {{ $record->id }})"
+                        wire:click.stop="executeRowAction('{{ $action->getKey() }}', {{ $record->id }})"
                         @if($action->getConfirmMessage())
                             onclick="return confirm('{{ $action->getConfirmMessage() }}')"
                         @endif

--- a/resources/views/partials/table-body.blade.php
+++ b/resources/views/partials/table-body.blade.php
@@ -3,15 +3,17 @@
         <tr
             @class([
                 'hover:bg-gray-50 dark:hover:bg-gray-700 py-4',
-                'bg-indigo-50 dark:bg-indigo-900/50' => $this->hasSelection() && $this->isSelected($row->id)
+                'bg-indigo-50 dark:bg-indigo-900/50' => $this->hasSelection() && $this->isSelected($row->id),
+                'cursor-pointer' => $this->hasShowRecord()
             ])
             wire:key="row-{{ $row->id }}"
+            @if($this->hasShowRecord()) wire:click="showRecord({{ $row->id }})" @endif
         >
             @if($this->hasSelection())
                 <td class="relative px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
                     <input
                         type="checkbox"
-                        wire:click="toggleSelection({{ $row->id }})"
+                        wire:click.stop="toggleSelection({{ $row->id }})"
                         @checked($this->isSelected($row->id))
                         class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded-xs focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600"
                     />

--- a/src/Columns/Column.php
+++ b/src/Columns/Column.php
@@ -32,7 +32,7 @@ class Column
     public function __construct(string $name)
     {
         $this->name = Str::headline($name);
-        $this->field = $name;
+        $this->field = Str::snake($name);
     }
 
     public static function make(string $name): static

--- a/src/Livewire/Table.php
+++ b/src/Livewire/Table.php
@@ -159,6 +159,27 @@ abstract class Table extends Component
     }
 
     /**
+     * Determine if the table has an override for the row click handler.
+     */
+    protected function hasShowRecord(): bool
+    {
+        $method = new \ReflectionMethod($this, 'showRecord');
+
+        return $method->getDeclaringClass()->getName() !== self::class;
+    }
+
+    /**
+     * Handle clicking on a row. Override in your table component.
+     *
+     * Typical implementations may redirect to a route or dispatch a Livewire
+     * event with the selected record ID.
+     */
+    public function showRecord(string|int $id): void
+    {
+        // Override in your table to define row click behaviour.
+    }
+
+    /**
      * Render the component.
      */
     public function render()


### PR DESCRIPTION
## Summary
- make constructor snake-case column field names
- add `showRecord` handler to Table for row click
- make table rows clickable when `showRecord` exists
- stop row click propagation from actions and selection checkboxes
- document clickable row usage in README
- add `hasShowRecord` helper so row clicks only work when overridden
- show how to dispatch events from `showRecord`

## Testing
- `composer test`
- `composer format`


------
https://chatgpt.com/codex/tasks/task_e_6864e0de70d48322a16719a40cc432f3