### PR TITLE
Fix ambiguous column names in queries

### DIFF
--- a/src/Concerns/HasSorting.php
+++ b/src/Concerns/HasSorting.php
@@ -91,6 +91,10 @@ trait HasSorting
             }
         }
 
+        if (! str_contains($sortField, '.')) {
+            $sortField = $query->getModel()->getTable() . '.' . $sortField;
+        }
+
         return $query->orderBy($sortField, $sortDirection);
     }
 

--- a/src/Filters/DateFilter.php
+++ b/src/Filters/DateFilter.php
@@ -56,11 +56,16 @@ class DateFilter extends Filter
                 });
             }
 
+            $field = $this->field;
+            if (! str_contains($field, '.')) {
+                $field = $query->getModel()->getTable() . '.' . $field;
+            }
+
             if (! empty($value['from'])) {
-                $query->where($this->field, '>=', Carbon::parse($value['from'])->startOfDay());
+                $query->where($field, '>=', Carbon::parse($value['from'])->startOfDay());
             }
             if (! empty($value['to'])) {
-                $query->where($this->field, '<=', Carbon::parse($value['to'])->endOfDay());
+                $query->where($field, '<=', Carbon::parse($value['to'])->endOfDay());
             }
 
             return $query;
@@ -72,7 +77,12 @@ class DateFilter extends Filter
             return $query->whereHas($relation, fn (Builder $q) => $q->whereDate($field, Carbon::parse($value)));
         }
 
-        return $query->whereDate($this->field, Carbon::parse($value));
+        $field = $this->field;
+        if (! str_contains($field, '.')) {
+            $field = $query->getModel()->getTable() . '.' . $field;
+        }
+
+        return $query->whereDate($field, Carbon::parse($value));
     }
 
     public function render(): string

--- a/src/Filters/SelectFilter.php
+++ b/src/Filters/SelectFilter.php
@@ -65,11 +65,16 @@ class SelectFilter extends Filter
             });
         }
 
-        if ($this->multiple && is_array($value)) {
-            return $query->whereIn($this->field, $value);
+        $field = $this->field;
+        if (! str_contains($field, '.')) {
+            $field = $query->getModel()->getTable() . '.' . $field;
         }
 
-        return $query->where($this->field, $value);
+        if ($this->multiple && is_array($value)) {
+            return $query->whereIn($field, $value);
+        }
+
+        return $query->where($field, $value);
     }
 
     public function render(): string

--- a/src/Filters/TextFilter.php
+++ b/src/Filters/TextFilter.php
@@ -61,12 +61,17 @@ class TextFilter extends Filter
             });
         }
 
+        $field = $this->field;
+        if (! str_contains($field, '.')) {
+            $field = $query->getModel()->getTable() . '.' . $field;
+        }
+
         return match ($this->operator) {
-            '=' => $query->where($this->field, '=', $value),
-            'like' => $query->where($this->field, 'like', "%{$value}%"),
-            'starts_with' => $query->where($this->field, 'like', "{$value}%"),
-            'ends_with' => $query->where($this->field, 'like', "%{$value}"),
-            default => $query->where($this->field, 'like', "%{$value}%"),
+            '=' => $query->where($field, '=', $value),
+            'like' => $query->where($field, 'like', "%{$value}%"),
+            'starts_with' => $query->where($field, 'like', "{$value}%"),
+            'ends_with' => $query->where($field, 'like', "%{$value}"),
+            default => $query->where($field, 'like', "%{$value}%"),
         };
     }
 

--- a/src/Livewire/Table.php
+++ b/src/Livewire/Table.php
@@ -117,6 +117,10 @@ abstract class Table extends Component
                         $subQuery->where($relationField, 'like', "%{$this->search}%");
                     });
                 } else {
+                    if (! str_contains($field, '.')) {
+                        $field = $query->getModel()->getTable() . '.' . $field;
+                    }
+
                     $query->orWhere($field, 'like', "%{$this->search}%");
                 }
             }

--- a/tests/Unit/Concerns/HasFiltersTest.php
+++ b/tests/Unit/Concerns/HasFiltersTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use ModusDigital\LivewireDatatables\Concerns\HasFilters;
 use ModusDigital\LivewireDatatables\Filters\SelectFilter;
 use ModusDigital\LivewireDatatables\Filters\TextFilter;
@@ -60,7 +61,9 @@ it('applies filters to query', function () {
         'status' => 'active',
     ];
 
+    $model = new class extends Model { protected $table = 'test_table'; };
     $query = Mockery::mock(Builder::class);
+    $query->shouldReceive('getModel')->andReturn($model)->byDefault();
     $query->shouldReceive('where')->twice()->andReturnSelf();
 
     $result = $this->component->applyFilters($query);
@@ -75,7 +78,9 @@ it('skips empty filter values', function () {
         'email' => [],
     ];
 
+    $model = new class extends Model { protected $table = 'test_table'; };
     $query = Mockery::mock(Builder::class);
+    $query->shouldReceive('getModel')->andReturn($model)->byDefault();
     $query->shouldNotReceive('where');
 
     $result = $this->component->applyFilters($query);

--- a/tests/Unit/Concerns/HasSortingTest.php
+++ b/tests/Unit/Concerns/HasSortingTest.php
@@ -93,8 +93,10 @@ it('applies basic sorting to query', function () {
     $this->component->sortField = 'name';
     $this->component->sortDirection = 'desc';
 
+    $model = new class extends Model { protected $table = 'test_table'; };
     $query = Mockery::mock(Builder::class);
-    $query->shouldReceive('orderBy')->once()->with('name', 'desc')->andReturnSelf();
+    $query->shouldReceive('getModel')->andReturn($model)->byDefault();
+    $query->shouldReceive('orderBy')->once()->with('test_table.name', 'desc')->andReturnSelf();
 
     $result = $this->component->applySorting($query);
 
@@ -102,8 +104,10 @@ it('applies basic sorting to query', function () {
 });
 
 it('applies default sorting when no sort field set', function () {
+    $model = new class extends Model { protected $table = 'test_table'; };
     $query = Mockery::mock(Builder::class);
-    $query->shouldReceive('orderBy')->once()->with('id', 'asc')->andReturnSelf();
+    $query->shouldReceive('getModel')->andReturn($model)->byDefault();
+    $query->shouldReceive('orderBy')->once()->with('test_table.id', 'asc')->andReturnSelf();
 
     $this->component->applySorting($query);
 });
@@ -111,8 +115,10 @@ it('applies default sorting when no sort field set', function () {
 it('uses custom sort field from column', function () {
     $this->component->sortField = 'custom_sort';
 
+    $model = new class extends Model { protected $table = 'test_table'; };
     $query = Mockery::mock(Builder::class);
-    $query->shouldReceive('orderBy')->once()->with('actual_field', 'asc')->andReturnSelf();
+    $query->shouldReceive('getModel')->andReturn($model)->byDefault();
+    $query->shouldReceive('orderBy')->once()->with('test_table.actual_field', 'asc')->andReturnSelf();
 
     $this->component->applySorting($query);
 });

--- a/tests/Unit/Filters/DateFilterTest.php
+++ b/tests/Unit/Filters/DateFilterTest.php
@@ -2,12 +2,21 @@
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use ModusDigital\LivewireDatatables\Filters\DateFilter;
 
 // Helper function to create mock query
 function createMockQueryForDateFilter(): Builder
 {
-    return Mockery::mock(Builder::class);
+    $model = new class extends Model
+    {
+        protected $table = 'test_table';
+    };
+
+    $mock = Mockery::mock(Builder::class);
+    $mock->shouldReceive('getModel')->andReturn($model)->byDefault();
+
+    return $mock;
 }
 
 beforeEach(function () {
@@ -50,7 +59,7 @@ it('sets custom format', function () {
 
 it('applies single date filter', function () {
     $query = createMockQueryForDateFilter();
-    $query->shouldReceive('whereDate')->once()->with('created_at', Mockery::type(Carbon::class))->andReturnSelf();
+    $query->shouldReceive('whereDate')->once()->with('test_table.created_at', Mockery::type(Carbon::class))->andReturnSelf();
 
     $this->filter->apply($query, '2024-01-01');
 });
@@ -68,7 +77,7 @@ it('applies partial date range filter with only from date', function () {
     $filter = DateFilter::make('Created At')->range();
 
     $query = createMockQueryForDateFilter();
-    $query->shouldReceive('where')->once()->with('created_at', '>=', Mockery::type(Carbon::class))->andReturnSelf();
+    $query->shouldReceive('where')->once()->with('test_table.created_at', '>=', Mockery::type(Carbon::class))->andReturnSelf();
 
     $filter->apply($query, ['from' => '2024-01-01']);
 });
@@ -77,7 +86,7 @@ it('applies partial date range filter with only to date', function () {
     $filter = DateFilter::make('Created At')->range();
 
     $query = createMockQueryForDateFilter();
-    $query->shouldReceive('where')->once()->with('created_at', '<=', Mockery::type(Carbon::class))->andReturnSelf();
+    $query->shouldReceive('where')->once()->with('test_table.created_at', '<=', Mockery::type(Carbon::class))->andReturnSelf();
 
     $filter->apply($query, ['to' => '2024-01-31']);
 });

--- a/tests/Unit/Filters/SelectFilterTest.php
+++ b/tests/Unit/Filters/SelectFilterTest.php
@@ -1,12 +1,21 @@
 <?php
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use ModusDigital\LivewireDatatables\Filters\SelectFilter;
 
 // Helper function to create mock query
 function createMockQueryForSelectFilter(): Builder
 {
-    return Mockery::mock(Builder::class);
+    $model = new class extends Model
+    {
+        protected $table = 'test_table';
+    };
+
+    $mock = Mockery::mock(Builder::class);
+    $mock->shouldReceive('getModel')->andReturn($model)->byDefault();
+
+    return $mock;
 }
 
 beforeEach(function () {
@@ -43,7 +52,7 @@ it('is not multiple by default', function () {
 
 it('applies single value filter', function () {
     $query = createMockQueryForSelectFilter();
-    $query->shouldReceive('where')->once()->with('status', 'active')->andReturnSelf();
+    $query->shouldReceive('where')->once()->with('test_table.status', 'active')->andReturnSelf();
 
     $this->filter->apply($query, 'active');
 });
@@ -52,7 +61,7 @@ it('applies multiple values filter', function () {
     $filter = SelectFilter::make('Status')->multiple();
 
     $query = createMockQueryForSelectFilter();
-    $query->shouldReceive('whereIn')->once()->with('status', ['active', 'pending'])->andReturnSelf();
+    $query->shouldReceive('whereIn')->once()->with('test_table.status', ['active', 'pending'])->andReturnSelf();
 
     $filter->apply($query, ['active', 'pending']);
 });

--- a/tests/Unit/Filters/TextFilterTest.php
+++ b/tests/Unit/Filters/TextFilterTest.php
@@ -1,12 +1,21 @@
 <?php
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use ModusDigital\LivewireDatatables\Filters\TextFilter;
 
 // Helper function to create mock query
 function createMockQueryForTextFilter(): Builder
 {
-    return Mockery::mock(Builder::class);
+    $model = new class extends Model
+    {
+        protected $table = 'test_table';
+    };
+
+    $mock = Mockery::mock(Builder::class);
+    $mock->shouldReceive('getModel')->andReturn($model)->byDefault();
+
+    return $mock;
 }
 
 beforeEach(function () {
@@ -40,14 +49,14 @@ it('uses exact operator', function () {
     $filter = TextFilter::make('Name')->exact();
 
     $query = createMockQueryForTextFilter();
-    $query->shouldReceive('where')->once()->with('name', '=', 'John')->andReturnSelf();
+    $query->shouldReceive('where')->once()->with('test_table.name', '=', 'John')->andReturnSelf();
 
     $filter->apply($query, 'John');
 });
 
 it('uses contains operator by default', function () {
     $query = createMockQueryForTextFilter();
-    $query->shouldReceive('where')->once()->with('name', 'like', '%John%')->andReturnSelf();
+    $query->shouldReceive('where')->once()->with('test_table.name', 'like', '%John%')->andReturnSelf();
 
     $this->filter->apply($query, 'John');
 });
@@ -56,7 +65,7 @@ it('uses contains operator explicitly', function () {
     $filter = TextFilter::make('Name')->contains();
 
     $query = createMockQueryForTextFilter();
-    $query->shouldReceive('where')->once()->with('name', 'like', '%John%')->andReturnSelf();
+    $query->shouldReceive('where')->once()->with('test_table.name', 'like', '%John%')->andReturnSelf();
 
     $filter->apply($query, 'John');
 });
@@ -65,7 +74,7 @@ it('uses starts with operator', function () {
     $filter = TextFilter::make('Name')->startsWith();
 
     $query = createMockQueryForTextFilter();
-    $query->shouldReceive('where')->once()->with('name', 'like', 'John%')->andReturnSelf();
+    $query->shouldReceive('where')->once()->with('test_table.name', 'like', 'John%')->andReturnSelf();
 
     $filter->apply($query, 'John');
 });
@@ -74,7 +83,7 @@ it('uses ends with operator', function () {
     $filter = TextFilter::make('Name')->endsWith();
 
     $query = createMockQueryForTextFilter();
-    $query->shouldReceive('where')->once()->with('name', 'like', '%John')->andReturnSelf();
+    $query->shouldReceive('where')->once()->with('test_table.name', 'like', '%John')->andReturnSelf();
 
     $filter->apply($query, 'John');
 });


### PR DESCRIPTION
## Summary
- qualify column names with the base table when filtering, sorting, or searching
- update unit tests for new table-qualified expectations

## Testing
- `composer install` *(fails: composer not found)*
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653a4a77048322a102a6d95225e82b